### PR TITLE
Consistent Metadata

### DIFF
--- a/lib/canonical_logs/absinthe_middleware.ex
+++ b/lib/canonical_logs/absinthe_middleware.ex
@@ -13,18 +13,16 @@ defmodule CanonicalLogs.AbsintheMiddleware do
   It will still use Absinthe's `:filter_variables` [config option](https://hexdocs.pm/absinthe/Absinthe.Logger.html#module-variable-filtering), but additionally uses it recursively.
   """
   def call(resolution, _opts) do
-    if is_nil(Logger.metadata()[:graphql_operation_name]) do
-      graphql_operation_name =
-        case Enum.find(resolution.path, &current_operation?/1) do
-          %Operation{name: name} when not is_nil(name) -> name
-          _ -> "#NULL"
-        end
-
-      Logger.metadata(graphql_operation_name: graphql_operation_name)
-
-      if resolution.arguments != %{} do
-        Logger.metadata(graphql_arguments: resolution.arguments)
+    graphql_operation_name =
+      case Enum.find(resolution.path, &current_operation?/1) do
+        %Operation{name: name} when not is_nil(name) -> name
+        _ -> "#NULL"
       end
+
+    Logger.metadata(graphql_operation_name: graphql_operation_name)
+
+    if resolution.arguments != %{} do
+      Logger.metadata(graphql_arguments: resolution.arguments)
     end
 
     resolution

--- a/test/canonical_logs/absinthe_middleware_test.exs
+++ b/test/canonical_logs/absinthe_middleware_test.exs
@@ -14,7 +14,6 @@ defmodule CanonicalLogs.AbsintheMiddlewareTest do
     end)
   end
 
-  @tag :focus
   test "logs the expected information for a GraphQL request by default" do
     CanonicalLogs.attach(
       filter_metadata_recursively: ["password"],

--- a/test/canonical_logs/absinthe_middleware_test.exs
+++ b/test/canonical_logs/absinthe_middleware_test.exs
@@ -51,5 +51,18 @@ defmodule CanonicalLogs.AbsintheMiddlewareTest do
     assert logs =~ "password=[FILTERED]"
     assert logs =~ "password_confirmation=[FILTERED]"
     refute logs =~ "variables="
+
+    [
+      ~r/request_id=/,
+      ~r/duration=/,
+      ~r/status=/,
+      ~r/method=/,
+      ~r/request_path=/,
+      ~r/graphql_operation_name/
+    ]
+    |> Enum.each(fn regex ->
+      matches = Regex.scan(regex, logs)
+      assert length(matches) == 1
+    end)
   end
 end

--- a/test/canonical_logs_test.exs
+++ b/test/canonical_logs_test.exs
@@ -28,6 +28,19 @@ defmodule CanonicalLogsTest do
     assert logs =~ "request_path=/hello"
     assert logs =~ "method=GET"
     assert logs =~ ~r/duration=\d/
+
+    [
+      ~r/request_id=/,
+      ~r/duration=/,
+      ~r/status=/,
+      ~r/method=/,
+      ~r/request_path=/,
+      ~r/params=/
+    ]
+    |> Enum.each(fn regex ->
+      matches = Regex.scan(regex, logs)
+      assert length(matches) == 1
+    end)
   end
 
   test "logs the configured conn_metadata" do

--- a/test/support/recursive_formatter.ex
+++ b/test/support/recursive_formatter.ex
@@ -58,7 +58,7 @@ defmodule CanonicalLogs.Support.RecursiveFormatter do
   defp format_value(value) do
     to_string(value)
   rescue
-    error -> nil
+    _error -> nil
   end
 
   defp lpad(num, length \\ 2) do

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -25,10 +25,6 @@ defmodule CanonicalLogs.Support.TestSchema do
   end
 
   def middleware(middleware, _, _) do
-    if Enum.member?(middleware, CanonicalLogs.AbsintheMiddleware) do
-      middleware
-    else
-      middleware ++ [CanonicalLogs.AbsintheMiddleware]
-    end
+    middleware ++ [CanonicalLogs.AbsintheMiddleware]
   end
 end

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -25,6 +25,10 @@ defmodule CanonicalLogs.Support.TestSchema do
   end
 
   def middleware(middleware, _, _) do
-    middleware ++ [CanonicalLogs.AbsintheMiddleware]
+    if Enum.member?(middleware, CanonicalLogs.AbsintheMiddleware) do
+      middleware
+    else
+      middleware ++ [CanonicalLogs.AbsintheMiddleware]
+    end
   end
 end


### PR DESCRIPTION
Previously, CanonicalLogs was accidentally logging its metadata twice. This ensures it only does it once.
